### PR TITLE
Add MutationObserver guard and diagnostic logging

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -227,10 +227,6 @@ async function updateTabTitle(tabId, tab) {
                 diagLog(`[DIAG][TAB ${tabId}] Title already matches rule — (re)installing guard only. title="${tab.title?.substring(0,60)}"`);
             }
 
-            // Record that we are enforcing a title on this tab (via guard)
-            tabModifiedTitles.set(tabId, matchedTitle);
-            saveState();
-
             // Inject the MutationObserver guard into the page regardless of whether the
             // title needed changing. This ensures the guard is always active when a rule
             // matches, even if the title happened to already be correct at evaluation time.
@@ -262,22 +258,30 @@ async function updateTabTitle(tabId, tab) {
                     window.__titleTamer_observer = obs;
                 })()`
             );
-            await browser.tabs.executeScript(tabId, { code: injectGuard }).catch(e => {
+            
+            try {
+                await browser.tabs.executeScript(tabId, { code: injectGuard });
+                
+                // Record that we are enforcing a title on this tab (via guard)
+                // ONLY after successful injection.
+                tabModifiedTitles.set(tabId, matchedTitle);
+                await saveState();
+                
+                diagLog(`[DIAG][TAB ${tabId}] GUARD ${needsTitleChange ? 'INJECT+' : 're-'}installed. tabModifiedTitles: "${tabModifiedTitles.get(tabId)?.substring(0,60)}"`);
+            } catch (e) {
                 if (e.message && e.message.includes("Missing host permission")) {
                     console.log(`[TAB ${tabId}] NOTICE: Transient host permission mismatch (Sync Engine will retry)`);
                 } else {
                     console.log(`[TAB ${tabId}] executeScript failed for ${tab.url}:`, e);
                 }
-            });
-            diagLog(`[DIAG][TAB ${tabId}] GUARD ${needsTitleChange ? 'INJECT+' : 're-'}installed. tabModifiedTitles: "${tabModifiedTitles.get(tabId)?.substring(0,60)}"`);
+            }
         } else {
             // NO patterns matched. 
             // If we previously modified this tab, we need to REVERT it natively.
             if (tabModifiedTitles.has(tabId)) {
                 const revertTo = tabOriginalTitles.get(tabId) || tab.title;
                 diagLog(`[DIAG][TAB ${tabId}] No pattern matched. REVERTING from "${tab.title?.substring(0,60)}" to "${revertTo?.substring(0,60)}".`);
-                tabModifiedTitles.delete(tabId);
-                saveState();
+                
                 // We keep the original in the map just in case.
                 
                 // Tear down the MutationObserver guard and revert the title
@@ -290,8 +294,18 @@ async function updateTabTitle(tabId, tab) {
                         document.title = ${JSON.stringify(revertTo)};
                     })()`
                 );
-                await browser.tabs.executeScript(tabId, { code: revertScript })
-                    .catch(e => console.log(`[TAB ${tabId}] executeScript revert failed for ${tab.url}:`, e));
+                
+                try {
+                    await browser.tabs.executeScript(tabId, { code: revertScript });
+                    
+                    // We only stop tracking the modification if the revert script actually ran.
+                    // This keeps the engine aware that the tab might still have an active guard
+                    // if the revert failed.
+                    tabModifiedTitles.delete(tabId);
+                    await saveState();
+                } catch (e) {
+                    console.log(`[TAB ${tabId}] executeScript revert failed for ${tab.url}:`, e);
+                }
             } else {
                 diagLog(`[DIAG][TAB ${tabId}] No pattern matched, no override active. Nothing to do.`);
             }

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -4,6 +4,17 @@
 const tabOriginalTitles = new Map(); // tabId -> String (the site's true, native title)
 const tabModifiedTitles = new Map(); // tabId -> String (the manipulated title we set)
 
+// Diagnostic logging — off by default, toggled via Options → Developer Tools.
+// The flag is cached in memory so diagLog() is a zero-cost boolean check when disabled.
+let diagLoggingEnabled = false;
+browser.storage.local.get('diagLogging').then(r => {
+    diagLoggingEnabled = r.diagLogging === true;
+}).catch(() => {});
+
+function diagLog(...args) {
+    if (diagLoggingEnabled) console.log(...args);
+}
+
 const syncStateUtils = (() => {
     if (globalThis.serializeSyncState && globalThis.hydrateSyncState) {
         return {
@@ -90,16 +101,41 @@ browser.tabs.onRemoved.addListener((tabId) => {
 
 // Monitor tab updates (navigation, title changes, loading complete)
 browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+    // [DIAG] Log every onUpdated event so we can see the full sequence
+    const ci = {};
+    if (changeInfo.title  !== undefined) ci.title  = changeInfo.title?.substring(0, 60);
+    if (changeInfo.url    !== undefined) ci.url    = changeInfo.url?.substring(0, 60);
+    if (changeInfo.status !== undefined) ci.status = changeInfo.status;
+    diagLog(`[DIAG][TAB ${tabId}] onUpdated | changeInfo=${JSON.stringify(ci)} | storedModified="${tabModifiedTitles.get(tabId)?.substring(0,40) ?? '(none)'}" | storedOriginal="${tabOriginalTitles.get(tabId)?.substring(0,40) ?? '(none)'}"`);
+
+    // A URL change signals genuine SPA/navigation. Reset our modified-title record so
+    // the incoming title from the new page is treated as the new original, not as the
+    // site "fighting back" against our override.
+    if (changeInfo.url && tabModifiedTitles.has(tabId)) {
+        diagLog(`[DIAG][TAB ${tabId}] URL change detected — clearing modified title record to allow fresh evaluation.`);
+        tabModifiedTitles.delete(tabId);
+        saveState();
+    }
+
     // Intercept title changes
     if (changeInfo.title) {
         if (changeInfo.title === tabModifiedTitles.get(tabId)) {
             // Echo from our own executeScript modifier. Ignore to prevent loops.
+            diagLog(`[DIAG][TAB ${tabId}] ECHO GUARD hit — title matches our injected value. Returning early.`);
             return;
         }
-        // Genuine native title change by the website (e.g. SPA navigation)
-        tabOriginalTitles.set(tabId, changeInfo.title);
+
         if (tabModifiedTitles.has(tabId)) {
-            saveState();
+            // We have an active override and the title changed WITHOUT a URL change.
+            // This is almost certainly the site re-asserting its own title post-hydration
+            // or via a JS framework (e.g. React, Angular, Costco-style SPA re-render).
+            // Do NOT update tabOriginalTitles — the value we stored on first load is still
+            // the true original. Simply fall through so updateTabTitle() re-applies our rule.
+            diagLog(`[DIAG][TAB ${tabId}] FIGHT-BACK detected — site set title to "${changeInfo.title?.substring(0, 60)}" while override is active. Will re-assert.`);
+        } else {
+            // No active override: this is a genuine native title change (e.g. SPA nav, new page).
+            diagLog(`[DIAG][TAB ${tabId}] Genuine native title change (no override active). Storing as original: "${changeInfo.title?.substring(0, 60)}".`);
+            tabOriginalTitles.set(tabId, changeInfo.title);
         }
     }
     
@@ -107,7 +143,14 @@ browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     if (changeInfo.title || changeInfo.url || changeInfo.status === 'complete') {
         // Fetch fresh tab to avoid race conditions (e.g. tab.url or tab.status being out-of-date)
         const freshTab = await browser.tabs.get(tabId).catch(() => null);
-        if (freshTab && freshTab.status === 'complete' && isInjectable(freshTab)) {
+        if (!freshTab) {
+            diagLog(`[DIAG][TAB ${tabId}] freshTab is null — tab may have closed. Skipping.`);
+        } else if (freshTab.status !== 'complete') {
+            diagLog(`[DIAG][TAB ${tabId}] freshTab.status=${freshTab.status} (not complete) — skipping updateTabTitle for now.`);
+        } else if (!isInjectable(freshTab)) {
+            diagLog(`[DIAG][TAB ${tabId}] freshTab is not injectable (url=${freshTab.url?.substring(0,60)}) — skipping.`);
+        } else {
+            diagLog(`[DIAG][TAB ${tabId}] Calling updateTabTitle | freshTab.title="${freshTab.title?.substring(0,60)}" | freshTab.status=${freshTab.status}`);
             updateTabTitle(tabId, freshTab);
         }
     }
@@ -139,54 +182,102 @@ async function updateTabTitle(tabId, tab) {
         const activePatterns = filterActivePatterns(sorted, disabledGroups);
 
         let matchedTitle = null;
+        let matchedPattern = null;
         for (const pattern of activePatterns) {
             const matchTest = applyPattern(tab.url, pattern);
             if (matchTest && matchTest.matched && matchTest.newTitle) {
                 matchedTitle = matchTest.newTitle;
+                matchedPattern = pattern;
                 break;
             }
         }
 
+        diagLog(`[DIAG][TAB ${tabId}] updateTabTitle | tab.title="${tab.title?.substring(0,60)}" | matchedTitle="${matchedTitle ?? '(none)'}" | activePatterns=${activePatterns.length}`);
+
         if (matchedTitle) {
-            // A pattern matched.
-            if (tab.title !== matchedTitle) {
+            // A pattern matched. Always (re)install the guard so the MutationObserver
+            // is present regardless of whether the current title already matches.
+            // This prevents a gap where the guard is absent if we skip injection because
+            // tab.title happened to equal matchedTitle at evaluation time.
+
+            const needsTitleChange = tab.title !== matchedTitle;
+            if (needsTitleChange) {
+                diagLog(`[DIAG][TAB ${tabId}] INJECTING title: "${matchedTitle}" (was: "${tab.title?.substring(0,60)}")`);
                 // Ensure we have captured the original title before overwriting it
                 if (!tabOriginalTitles.has(tabId) && typeof tab.title === 'string') {
                      tabOriginalTitles.set(tabId, tab.title);
                      saveState();
                 }
-                
                 // Record our change
                 tabModifiedTitles.set(tabId, matchedTitle);
                 saveState();
-                
-                // Inject the change
-                await browser.tabs.executeScript(tabId, {
-                    code: `document.title = ${JSON.stringify(matchedTitle)};`
-                }).catch(e => {
-                    // Suppress "Missing host permission" noise for transient reload states
-                    if (e.message && e.message.includes("Missing host permission")) {
-                        console.log(`[TAB ${tabId}] NOTICE: Transient host permission mismatch (Sync Engine will retry)`);
-                    } else {
-                        console.log(`[TAB ${tabId}] executeScript failed for ${tab.url}:`, e);
-                    }
-                });
+            } else {
+                diagLog(`[DIAG][TAB ${tabId}] Title already matches rule — (re)installing guard only. title="${tab.title?.substring(0,60)}"`);
             }
+
+            // Inject the MutationObserver guard into the page regardless of whether the
+            // title needed changing. This ensures the guard is always active when a rule
+            // matches, even if the title happened to already be correct at evaluation time.
+            const injectGuard = (
+                `(function() {
+                    const TARGET = ${JSON.stringify(matchedTitle)};
+                    // Disconnect any previous Title Tamer observer first
+                    if (window.__titleTamer_observer) {
+                        window.__titleTamer_observer.disconnect();
+                        window.__titleTamer_observer = null;
+                    }
+                    // Apply the title immediately
+                    document.title = TARGET;
+                    // Find or create the <title> element
+                    let titleEl = document.querySelector('title');
+                    if (!titleEl) {
+                        titleEl = document.createElement('title');
+                        document.head.appendChild(titleEl);
+                    }
+                    // Install a MutationObserver to re-assert our title if the site changes it
+                    const obs = new MutationObserver(() => {
+                        if (document.title !== TARGET) {
+                            document.title = TARGET;
+                        }
+                    });
+                    obs.observe(titleEl, { childList: true, characterData: true, subtree: true });
+                    // Also observe the <head> in case the site removes/replaces <title>
+                    obs.observe(document.head, { childList: true });
+                    window.__titleTamer_observer = obs;
+                })()`
+            );
+            await browser.tabs.executeScript(tabId, { code: injectGuard }).catch(e => {
+                if (e.message && e.message.includes("Missing host permission")) {
+                    console.log(`[TAB ${tabId}] NOTICE: Transient host permission mismatch (Sync Engine will retry)`);
+                } else {
+                    console.log(`[TAB ${tabId}] executeScript failed for ${tab.url}:`, e);
+                }
+            });
+            diagLog(`[DIAG][TAB ${tabId}] GUARD ${needsTitleChange ? 'INJECT+' : 're-'}installed. tabModifiedTitles: "${tabModifiedTitles.get(tabId)?.substring(0,60)}"`);
         } else {
             // NO patterns matched. 
             // If we previously modified this tab, we need to REVERT it natively.
             if (tabModifiedTitles.has(tabId)) {
                 const revertTo = tabOriginalTitles.get(tabId) || tab.title;
+                diagLog(`[DIAG][TAB ${tabId}] No pattern matched. REVERTING from "${tab.title?.substring(0,60)}" to "${revertTo?.substring(0,60)}".`);
                 tabModifiedTitles.delete(tabId);
                 saveState();
                 // We keep the original in the map just in case.
                 
-                // Inject the revert
-                if (tab.title !== revertTo) {
-                    await browser.tabs.executeScript(tabId, {
-                        code: `document.title = ${JSON.stringify(revertTo)};`
-                    }).catch(e => console.log(`[TAB ${tabId}] executeScript revert failed for ${tab.url}:`, e));                
-                }
+                // Tear down the MutationObserver guard and revert the title
+                const revertScript = (
+                    `(function() {
+                        if (window.__titleTamer_observer) {
+                            window.__titleTamer_observer.disconnect();
+                            window.__titleTamer_observer = null;
+                        }
+                        document.title = ${JSON.stringify(revertTo)};
+                    })()`
+                );
+                await browser.tabs.executeScript(tabId, { code: revertScript })
+                    .catch(e => console.log(`[TAB ${tabId}] executeScript revert failed for ${tab.url}:`, e));
+            } else {
+                diagLog(`[DIAG][TAB ${tabId}] No pattern matched, no override active. Nothing to do.`);
             }
         }
 
@@ -198,6 +289,10 @@ async function updateTabTitle(tabId, tab) {
 // Universal Sync Receiver: Triggered automatically whenever rules or active statuses change in storage
 browser.storage.onChanged.addListener((changes, areaName) => {
     if (areaName === 'local') {
+        // Keep the in-memory diagLogging flag in sync so the toggle takes effect immediately
+        if (changes.diagLogging !== undefined) {
+            diagLoggingEnabled = changes.diagLogging.newValue === true;
+        }
         if (changes.patterns || changes.disabledGroups) {
             console.log('Rule set updated. Triggering universal sync.');
             syncAllTabs();

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -101,6 +101,8 @@ browser.tabs.onRemoved.addListener((tabId) => {
 
 // Monitor tab updates (navigation, title changes, loading complete)
 browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+    await loggingReady;
+    
     // [DIAG] Log every onUpdated event so we can see the full sequence
     const ci = {};
     if (changeInfo.title  !== undefined) ci.title  = changeInfo.title?.substring(0, 60);
@@ -112,7 +114,6 @@ browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     // the incoming title from the new page is treated as the new original, not as the
     // site "fighting back" against our override.
     if (changeInfo.url && tabModifiedTitles.has(tabId)) {
-        await loggingReady;
         diagLog(`[DIAG][TAB ${tabId}] URL change detected — clearing modified title record and disconnecting guard.`);
         
         // Explicitly disconnect the guard before clearing the record.
@@ -132,7 +133,6 @@ browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
     // Intercept title changes
     if (changeInfo.title) {
-        await loggingReady;
         if (changeInfo.title === tabModifiedTitles.get(tabId)) {
             // Echo from our own executeScript modifier. Ignore to prevent loops.
             diagLog(`[DIAG][TAB ${tabId}] ECHO GUARD hit — title matches our injected value. Returning early.`);
@@ -172,11 +172,11 @@ browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 
 // Capture native title on tab creation
 browser.tabs.onCreated.addListener(async (tab) => {
+    await loggingReady;
     if (!isInjectable(tab)) return;
     if (tab.title) {
         tabOriginalTitles.set(tab.id, tab.title);
     }
-    await loggingReady;
     updateTabTitle(tab.id, tab);
 });
 

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -254,7 +254,9 @@ async function updateTabTitle(tabId, tab) {
                     });
                     obs.observe(titleEl, { childList: true, characterData: true, subtree: true });
                     // Also observe the <head> in case the site removes/replaces <title>
-                    obs.observe(document.head, { childList: true });
+                    // We use subtree: true to ensure we catch characterData changes
+                    // even if the <title> node itself is replaced by the site.
+                    obs.observe(document.head, { childList: true, subtree: true, characterData: true });
                     window.__titleTamer_observer = obs;
                 })()`
             );

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -7,7 +7,7 @@ const tabModifiedTitles = new Map(); // tabId -> String (the manipulated title w
 // Diagnostic logging — off by default, toggled via Options → Developer Tools.
 // The flag is cached in memory so diagLog() is a zero-cost boolean check when disabled.
 let diagLoggingEnabled = false;
-browser.storage.local.get('diagLogging').then(r => {
+const loggingReady = browser.storage.local.get('diagLogging').then(r => {
     diagLoggingEnabled = r.diagLogging === true;
 }).catch(() => {});
 
@@ -112,13 +112,27 @@ browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
     // the incoming title from the new page is treated as the new original, not as the
     // site "fighting back" against our override.
     if (changeInfo.url && tabModifiedTitles.has(tabId)) {
-        diagLog(`[DIAG][TAB ${tabId}] URL change detected — clearing modified title record to allow fresh evaluation.`);
+        await loggingReady;
+        diagLog(`[DIAG][TAB ${tabId}] URL change detected — clearing modified title record and disconnecting guard.`);
+        
+        // Explicitly disconnect the guard before clearing the record.
+        // This prevents the observer from re-asserting the old custom title 
+        // if the URL change was a partial SPA navigation without a Full Page Reload.
+        const disconnectScript = `(function() {
+            if (window.__titleTamer_observer) {
+                window.__titleTamer_observer.disconnect();
+                window.__titleTamer_observer = null;
+            }
+        })()`;
+        await browser.tabs.executeScript(tabId, { code: disconnectScript }).catch(() => {});
+        
         tabModifiedTitles.delete(tabId);
         saveState();
     }
 
     // Intercept title changes
     if (changeInfo.title) {
+        await loggingReady;
         if (changeInfo.title === tabModifiedTitles.get(tabId)) {
             // Echo from our own executeScript modifier. Ignore to prevent loops.
             diagLog(`[DIAG][TAB ${tabId}] ECHO GUARD hit — title matches our injected value. Returning early.`);
@@ -157,11 +171,12 @@ browser.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 });
 
 // Capture native title on tab creation
-browser.tabs.onCreated.addListener((tab) => {
+browser.tabs.onCreated.addListener(async (tab) => {
     if (!isInjectable(tab)) return;
     if (tab.title) {
         tabOriginalTitles.set(tab.id, tab.title);
     }
+    await loggingReady;
     updateTabTitle(tab.id, tab);
 });
 
@@ -208,12 +223,13 @@ async function updateTabTitle(tabId, tab) {
                      tabOriginalTitles.set(tabId, tab.title);
                      saveState();
                 }
-                // Record our change
-                tabModifiedTitles.set(tabId, matchedTitle);
-                saveState();
             } else {
                 diagLog(`[DIAG][TAB ${tabId}] Title already matches rule — (re)installing guard only. title="${tab.title?.substring(0,60)}"`);
             }
+
+            // Record that we are enforcing a title on this tab (via guard)
+            tabModifiedTitles.set(tabId, matchedTitle);
+            saveState();
 
             // Inject the MutationObserver guard into the page regardless of whether the
             // title needed changing. This ensures the guard is always active when a rule
@@ -458,33 +474,18 @@ async function syncAllTabs() {
                         console.log(`[TAB ${tabId}] STATE: discarded=${afterLoad.discarded}, status=${afterLoad.status}, title="${afterLoad.title?.substring(0, 40)}"`);
                     }
 
-                    // Verify/inject the correct title after waking the tab
+                    // Verify/inject the correct title after waking the tab.
+                    // We delegate to updateTabTitle here so the MutationObserver guard 
+                    // is installed consistently with the normal loaded-tab path,
+                    // preventing fight-back on freshly-woken tabs.
                     try {
                         const finalTab = await browser.tabs.get(tabId);
-                        if (expectedTitle && finalTab.title !== expectedTitle) {
-                            console.log(`[TAB ${tabId}] TITLE UPDATE REQUIRED: have="${finalTab.title?.substring(0, 30)}...", want="${expectedTitle?.substring(0, 30)}..."`);
-                            await browser.tabs.executeScript(tabId, {
-                                code: `document.title = ${JSON.stringify(expectedTitle)};`
-                            }).catch((e) => console.log(`[TAB ${tabId}] INJECT FAILED for ${originalTab.url}:`, e));
-                            tabModifiedTitles.set(tabId, expectedTitle);
-                            saveState();
-                        } else {
-                            if (expectedTitle) {
-                                const ruleId = matchingPattern.name || matchingPattern.search;
-                                console.log(`[TAB ${tabId}] TITLE OK: Matches rule "${ruleId}"`);
-                            } else {
-                                // No rule matches, and title is correct? ensure we are clean.
-                                if (tabModifiedTitles.has(tabId)) {
-                                    tabModifiedTitles.delete(tabId);
-                                    saveState();
-                                    console.log(`[TAB ${tabId}] REVERT COMPLETE: Persistent record cleared.`);
-                                } else {
-                                    console.log(`[TAB ${tabId}] TITLE RETAINED: No active rule match.`);
-                                }
-                            }
+                        if (finalTab) {
+                            await updateTabTitle(tabId, finalTab);
+                            console.log(`[TAB ${tabId}] Wake-up sync complete (via updateTabTitle).`);
                         }
                     } catch (e) {
-                        console.log(`[TAB ${tabId}] TITLE CHECK ERROR:`, e);
+                        console.log(`[TAB ${tabId}] TITLE UPDATE ERROR:`, e);
                     }
 
                     // Re-discard the tab if required
@@ -516,11 +517,8 @@ async function syncAllTabs() {
                             }
                             await new Promise(r => setTimeout(r, 500));
                         }
-                        console.log(`[TAB ${tabId}] DONE: discarded=${discarded}`);
                     }
-                } catch (e) {
-                    console.error(`[TAB ${tabId}] ERROR:`, e);
-                }
+                } catch (e) {}
             };
 
             // Rolling worker pool: each worker pulls from a shared queue sequentially.

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -529,12 +529,16 @@ async function syncAllTabs() {
                                     if (otherTab) {
                                         await browser.tabs.update(otherTab.id, { active: true });
                                     }
-                                } catch (_) {}
+                                } catch (err) {
+                                    diagLog(`[DIAG][TAB ${tabId}] Recovery: Failed to switch active tab during discard attempt ${attempt + 1}:`, err);
+                                }
                             }
                             await new Promise(r => setTimeout(r, 500));
                         }
                     }
-                } catch (e) {}
+                } catch (e) {
+                    console.error(`[SYNC][TAB ${tabId}] Phase 2 (wake/reload/discard) failed:`, e);
+                }
             };
 
             // Rolling worker pool: each worker pulls from a shared queue sequentially.

--- a/src/options/options.css
+++ b/src/options/options.css
@@ -217,6 +217,35 @@ thead th {
     cursor: pointer;
 }
 
+/* Inline hint in the Developer Tools checkbox label */
+.dev-tools-hint {
+    font-size: 0.8em;
+    opacity: 0.6;
+    white-space: nowrap;
+}
+
+/* Inline row: places two form-group2 cells side-by-side on one line */
+.options-inline-row {
+    display: flex;
+    gap: 0;
+    align-items: stretch;
+    margin-bottom: 4px;
+}
+
+.options-inline-cell {
+    flex: 1 1 auto;
+}
+
+.options-inline-cell fieldset {
+    height: 100%;
+    box-sizing: border-box;
+}
+
+/* Shrinks to fit its content (Import/Export button) instead of growing */
+.options-inline-cell--shrink {
+    flex: 0 0 auto;
+}
+
 /* Replaces inline style="display: block;" for nested options */
 .nested-options.show {
     display: block;

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -78,26 +78,7 @@
                     </div>
                 </fieldset>
             </div>
-            <!-- Theme Section -->
-            <div class="form-group2">
-                <fieldset class="theme-preferences-fieldset">
-                    <legend class="theme-preferences-legend">Theme</legend>
-                    <div class="segmented-control">
-                        <label>
-                            <input type="radio" name="theme" id="theme-light" value="light" checked />
-                            Light
-                        </label>
-                        <label>
-                            <input type="radio" name="theme" id="theme-dark" value="dark" />
-                            Dark
-                        </label>
-                        <label>
-                            <input type="radio" name="theme" id="theme-system" value="system" />
-                            System
-                        </label>
-                    </div>
-                </fieldset>
-            </div>
+            <!-- Group Options (full-width row) -->
             <div class="form-group2">
                 <fieldset class="group-sort-order-fieldset">
                     <legend class="group-sort-order-legend">Group Options</legend>
@@ -124,8 +105,29 @@
                     </label>
                 </fieldset>
             </div>
-            <!-- Export and Import Options -->
-            <div class="form-group2">
+            <!-- Theme + Import/Export on one row -->
+            <div class="options-inline-row">
+            <div class="form-group2 options-inline-cell">
+                <fieldset class="theme-preferences-fieldset">
+                    <legend class="theme-preferences-legend">Theme</legend>
+                    <div class="segmented-control">
+                        <label>
+                            <input type="radio" name="theme" id="theme-light" value="light" checked />
+                            Light
+                        </label>
+                        <label>
+                            <input type="radio" name="theme" id="theme-dark" value="dark" />
+                            Dark
+                        </label>
+                        <label>
+                            <input type="radio" name="theme" id="theme-system" value="system" />
+                            System
+                        </label>
+                    </div>
+                </fieldset>
+            </div>
+            <!-- Import/Export (paired with Theme) -->
+            <div class="form-group2 options-inline-cell options-inline-cell--shrink">
                 <fieldset class="import-export-fieldset">
                     <legend>Import/Export</legend>
                     <div style="display: flex; justify-content: flex-end; width: 100%;">
@@ -133,6 +135,18 @@
                             Import/Export Options <img class="open-icon" src="../icons/open.png" alt="Open in new tab">
                         </button>
                     </div>
+                </fieldset>
+            </div>
+            </div><!-- end options-inline-row -->
+            <!-- Developer Tools -->
+            <div class="form-group2">
+                <fieldset class="dev-tools-fieldset">
+                    <legend>Developer Tools</legend>
+                    <label class="block-label">
+                        <input type="checkbox" id="diag-logging-option" />
+                        Enable verbose diagnostic logging
+                        <span class="dev-tools-hint">&mdash; view output in <em>about:debugging</em> &rarr; This Firefox &rarr; Title Tamer &rarr; Inspect</span>
+                    </label>
                 </fieldset>
             </div>
         </div>

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -204,7 +204,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         groupSortOrder,
         showRecentGroupFirst,
         showGroupRuleCount,
-        recentGroupSelection: storedRecentGroupSelection
+        recentGroupSelection: storedRecentGroupSelection,
+        diagLogging,
     } = await browser.storage.local.get([
         'loadDiscardedTabs',
         'reDiscardTabs',
@@ -214,7 +215,8 @@ document.addEventListener('DOMContentLoaded', async () => {
         'groupSortOrder',
         'showRecentGroupFirst',
         'showGroupRuleCount',
-        'recentGroupSelection'
+        'recentGroupSelection',
+        'diagLogging',
     ]);
 
     groupSortOrderPreference = groupSortOrder || 'alphabetic';
@@ -311,6 +313,15 @@ document.addEventListener('DOMContentLoaded', async () => {
             browser.storage.local.set({ maxConcurrentTabs });
         }
     });
+
+    // Diagnostic logging toggle
+    const diagLoggingCheckbox = document.getElementById('diag-logging-option');
+    if (diagLoggingCheckbox) {
+        diagLoggingCheckbox.checked = diagLogging === true;
+        diagLoggingCheckbox.addEventListener('change', function () {
+            browser.storage.local.set({ diagLogging: this.checked });
+        });
+    }
 
     const table = document.getElementById('pattern-table');
     const scrollContainer = document.querySelector('.patterns-table-container');

--- a/tests/integration/background-sync.test.js
+++ b/tests/integration/background-sync.test.js
@@ -154,7 +154,7 @@ describe('background sync integration', function () {
         global.evaluateTabSyncState = previousEvaluateTabSyncState;
     });
 
-    it('syncAllTabs updates a loaded tab with a matching rule', async function () {
+    it('syncAllTabs updates a loaded tab with a matching rule and injects MutationObserver guard', async function () {
         const tab = {
             id: 101,
             url: 'https://www.google.com/search?q=title+tamer',
@@ -184,7 +184,11 @@ describe('background sync integration', function () {
 
         expect(env.calls.tabsExecuteScript).to.have.lengthOf(1);
         expect(env.calls.tabsExecuteScript[0].tabId).to.equal(101);
+        // Verify the injected code contains our expected title
         expect(env.calls.tabsExecuteScript[0].payload.code).to.contain('G: google.com');
+        // Verify the MutationObserver guard is injected (not a plain document.title assignment)
+        expect(env.calls.tabsExecuteScript[0].payload.code).to.contain('MutationObserver');
+        expect(env.calls.tabsExecuteScript[0].payload.code).to.contain('__titleTamer_observer');
     });
 
     it('syncAllTabs queues a second run if called while syncing', async function () {
@@ -252,5 +256,217 @@ describe('background sync integration', function () {
         await new Promise((resolve) => setTimeout(resolve, 25));
 
         expect(env.calls.tabsQuery).to.equal(1);
+    });
+});
+
+describe('fight-back detection (onUpdated behaviour)', function () {
+    let previousBrowser;
+    let previousApplyPattern;
+    let previousSortPatternsForDisplay;
+    let previousFilterActivePatterns;
+    let previousEvaluateTabSyncState;
+
+    beforeEach(function () {
+        delete require.cache[require.resolve('../../src/background/background.js')];
+        previousBrowser = global.browser;
+        previousApplyPattern = global.applyPattern;
+        previousSortPatternsForDisplay = global.sortPatternsForDisplay;
+        previousFilterActivePatterns = global.filterActivePatterns;
+        previousEvaluateTabSyncState = global.evaluateTabSyncState;
+        global.applyPattern = applyPattern;
+        global.sortPatternsForDisplay = sortPatternsForDisplay;
+        global.filterActivePatterns = filterActivePatterns;
+        global.evaluateTabSyncState = evaluateTabSyncState;
+    });
+
+    afterEach(function () {
+        global.browser = previousBrowser;
+        global.applyPattern = previousApplyPattern;
+        global.sortPatternsForDisplay = previousSortPatternsForDisplay;
+        global.filterActivePatterns = previousFilterActivePatterns;
+        global.evaluateTabSyncState = previousEvaluateTabSyncState;
+    });
+
+    it('site fight-back does NOT overwrite tabOriginalTitles when override is active', async function () {
+        // Scenario: we have already injected a custom title (tabModifiedTitles is set).
+        // The site then changes the title back to its own — this should NOT be recorded
+        // as the new original. The guard re-asserts our title instead.
+        const tab = {
+            id: 201,
+            url: 'https://www.costco.com/fish-oil-omega-3.html',
+            title: 'Custom Title',  // our injected title
+            status: 'complete',
+            discarded: false,
+            windowId: 1,
+        };
+
+        const env = createBrowserMock(
+            {
+                patterns: [{ name: 'Costco', search: 'costco\\.com', title: 'Custom Title' }],
+                disabledGroups: [],
+                loadDiscardedTabs: false,
+                reDiscardTabs: false,
+                discardDelay: 0,
+                limitConcurrentTabsEnabled: true,
+                maxConcurrentTabs: 10,
+            },
+            [tab]
+        );
+
+        global.browser = env.browser;
+        const background = require('../../src/background/background.js');
+
+        // Simulate background having previously injected our title
+        // by pre-seeding the state maps via a syncAllTabs pass first
+        await background.syncAllTabs();
+        const scriptCallsAfterSync = env.calls.tabsExecuteScript.length;
+
+        // Now simulate the site fighting back: onUpdated fires with the site's own title
+        // while our override is still active
+        tab.title = 'Fish Oil & Omega-3 | Costco';  // update the mock tab too
+        const fightBackChangeInfo = { title: 'Fish Oil & Omega-3 | Costco' };  // no url change
+
+        await env.listeners.tabsOnUpdatedListeners[0](tab.id, fightBackChangeInfo, tab);
+        // Give async work time to settle
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // The guard should have re-injected our title
+        expect(env.calls.tabsExecuteScript.length).to.be.greaterThan(scriptCallsAfterSync);
+        // The re-injected code should still target our custom title
+        const lastScript = env.calls.tabsExecuteScript[env.calls.tabsExecuteScript.length - 1];
+        expect(lastScript.payload.code).to.contain('Custom Title');
+        expect(lastScript.payload.code).to.contain('MutationObserver');
+    });
+
+    it('URL change clears the modified title record to allow fresh evaluation', async function () {
+        const tab = {
+            id: 202,
+            url: 'https://example.com/page-a',
+            title: 'My Custom Title',
+            status: 'loading',
+            discarded: false,
+            windowId: 1,
+        };
+
+        const env = createBrowserMock(
+            { patterns: [], disabledGroups: [], loadDiscardedTabs: false, reDiscardTabs: false, discardDelay: 0, limitConcurrentTabsEnabled: true, maxConcurrentTabs: 10 },
+            [tab]
+        );
+
+        global.browser = env.browser;
+        const background = require('../../src/background/background.js');
+
+        // Manually seed tabModifiedTitles to simulate a prior injection
+        // (we do that by running a sync that injects, but the pattern list is empty,
+        //  so instead we fire an onUpdated with status:complete + a matching rule)
+        // For this test we verify via the URL-change path — when URL fires, modified should clear.
+        // We can't directly reach internal maps, so we check indirectly: after URL change,
+        // a title event should be treated as a genuine original (not a fight-back).
+
+        // Fire URL change event
+        const urlChangeInfo = { url: 'https://example.com/page-b', status: 'loading' };
+        tab.url = 'https://example.com/page-b';
+        await env.listeners.tabsOnUpdatedListeners[0](tab.id, urlChangeInfo, tab);
+
+        // Then fire a title event — should be treated as genuine (no fight-back suppression)
+        const titleChangeInfo = { title: 'Page B Native Title' };
+        await env.listeners.tabsOnUpdatedListeners[0](tab.id, titleChangeInfo, tab);
+        await new Promise((resolve) => setTimeout(resolve, 25));
+
+        // No script should have been injected (no matching pattern, no override)
+        expect(env.calls.tabsExecuteScript).to.have.lengthOf(0);
+    });
+
+    it('guard is re-installed even when tab title already matches the rule', async function () {
+        // Scenario: tab.title already equals matchedTitle at evaluation time.
+        // This happens e.g. after a fight-back re-inject lands and we re-evaluate.
+        // updateTabTitle must still install the MutationObserver guard, not silently skip.
+        // Note: syncAllTabs() uses evaluateTabSyncState() which correctly returns needsUpdate=false
+        // when title already matches — that is correct sync engine behavior. This test calls
+        // updateTabTitle directly to verify the guard is unconditionally installed.
+        const tab = {
+            id: 203,
+            url: 'https://www.costco.com/fish-oil-omega-3.html',
+            title: 'HTTP31',  // already matches the rule — no title change needed
+            status: 'complete',
+            discarded: false,
+            windowId: 1,
+        };
+
+        const env = createBrowserMock(
+            {
+                patterns: [{ name: 'Costco', search: 'costco\\.com', title: 'HTTP31' }],
+                disabledGroups: [],
+                loadDiscardedTabs: false,
+                reDiscardTabs: false,
+                discardDelay: 0,
+                limitConcurrentTabsEnabled: true,
+                maxConcurrentTabs: 10,
+            },
+            [tab]
+        );
+
+        global.browser = env.browser;
+        const background = require('../../src/background/background.js');
+
+        // Call updateTabTitle directly — syncAllTabs() skips this tab via needsUpdate=false
+        await background.updateTabTitle(tab.id, tab);
+
+        // Even though the title was already correct, the guard MUST have been injected
+        expect(env.calls.tabsExecuteScript).to.have.lengthOf(1);
+        expect(env.calls.tabsExecuteScript[0].payload.code).to.contain('MutationObserver');
+        expect(env.calls.tabsExecuteScript[0].payload.code).to.contain('__titleTamer_observer');
+        expect(env.calls.tabsExecuteScript[0].payload.code).to.contain('HTTP31');
+    });
+
+    it('revert inject disconnects the MutationObserver guard before restoring title', async function () {
+        // When a rule is removed/disabled and we revert a tab, we must disconnect
+        // the in-page MutationObserver guard first, otherwise it would immediately
+        // re-assert our (now-removed) custom title, undoing the revert.
+        const originalNativeTitle = 'Fish Oil & Omega-3 | Costco';
+        const tab = {
+            id: 204,
+            url: 'https://www.costco.com/fish-oil-omega-3.html',
+            title: originalNativeTitle,
+            status: 'complete',
+            discarded: false,
+            windowId: 1,
+        };
+
+        const env = createBrowserMock(
+            {
+                patterns: [{ name: 'Costco', search: 'costco\\.com', title: 'HTTP31' }],
+                disabledGroups: [],
+                loadDiscardedTabs: false,
+                reDiscardTabs: false,
+                discardDelay: 0,
+                limitConcurrentTabsEnabled: true,
+                maxConcurrentTabs: 10,
+            },
+            [tab]
+        );
+
+        global.browser = env.browser;
+        const background = require('../../src/background/background.js');
+
+        // Phase 1: inject our custom title (seeds tabModifiedTitles + tabOriginalTitles)
+        await background.updateTabTitle(tab.id, tab);
+        expect(env.calls.tabsExecuteScript).to.have.lengthOf(1);
+        expect(env.calls.tabsExecuteScript[0].payload.code).to.contain('HTTP31');
+
+        // Phase 2: rule is deleted — update storage and call updateTabTitle again.
+        // Tab currently shows our injected title; no pattern matches -> revert path.
+        env.store.patterns = [];
+        tab.title = 'HTTP31';  // tab is currently showing our injected title
+        await background.updateTabTitle(tab.id, tab);
+
+        // The revert script must disconnect the observer AND restore the original title
+        expect(env.calls.tabsExecuteScript).to.have.lengthOf(2);
+        const revertScript = env.calls.tabsExecuteScript[1];
+        expect(revertScript.payload.code).to.contain('__titleTamer_observer');
+        expect(revertScript.payload.code).to.contain('disconnect');
+        // Should revert to the original native title, not our custom one
+        expect(revertScript.payload.code).to.contain(originalNativeTitle);
+        expect(revertScript.payload.code).not.to.contain('HTTP31');
     });
 });

--- a/tests/integration/background-sync.test.js
+++ b/tests/integration/background-sync.test.js
@@ -338,43 +338,61 @@ describe('fight-back detection (onUpdated behaviour)', function () {
         expect(lastScript.payload.code).to.contain('MutationObserver');
     });
 
-    it('URL change clears the modified title record to allow fresh evaluation', async function () {
+    it('URL change clears the modified title record and disconnects the guard', async function () {
         const tab = {
             id: 202,
             url: 'https://example.com/page-a',
-            title: 'My Custom Title',
-            status: 'loading',
+            title: 'Initial Title A',
+            status: 'complete',
             discarded: false,
             windowId: 1,
         };
 
         const env = createBrowserMock(
-            { patterns: [], disabledGroups: [], loadDiscardedTabs: false, reDiscardTabs: false, discardDelay: 0, limitConcurrentTabsEnabled: true, maxConcurrentTabs: 10 },
+            { 
+                patterns: [{ name: 'Example', search: 'example\\.com', title: 'My Custom Title' }], 
+                disabledGroups: [], 
+                loadDiscardedTabs: false, 
+                reDiscardTabs: false, 
+                discardDelay: 0, 
+                limitConcurrentTabsEnabled: true, 
+                maxConcurrentTabs: 10 
+            },
             [tab]
         );
 
         global.browser = env.browser;
         const background = require('../../src/background/background.js');
 
-        // Manually seed tabModifiedTitles to simulate a prior injection
-        // (we do that by running a sync that injects, but the pattern list is empty,
-        //  so instead we fire an onUpdated with status:complete + a matching rule)
-        // For this test we verify via the URL-change path — when URL fires, modified should clear.
-        // We can't directly reach internal maps, so we check indirectly: after URL change,
-        // a title event should be treated as a genuine original (not a fight-back).
+        // Phase 1: Set up modified state by triggering an update
+        await background.updateTabTitle(tab.id, tab);
+        expect(env.calls.tabsExecuteScript).to.have.lengthOf(1);
+        expect(env.calls.tabsExecuteScript[0].payload.code).to.contain('MutationObserver');
 
         // Fire URL change event
         const urlChangeInfo = { url: 'https://example.com/page-b', status: 'loading' };
         tab.url = 'https://example.com/page-b';
         await env.listeners.tabsOnUpdatedListeners[0](tab.id, urlChangeInfo, tab);
 
-        // Then fire a title event — should be treated as genuine (no fight-back suppression)
-        const titleChangeInfo = { title: 'Page B Native Title' };
-        await env.listeners.tabsOnUpdatedListeners[0](tab.id, titleChangeInfo, tab);
-        await new Promise((resolve) => setTimeout(resolve, 25));
+        // Verify that a disconnect script was injected (on loading status)
+        expect(env.calls.tabsExecuteScript).to.have.lengthOf(2);
+        expect(env.calls.tabsExecuteScript[1].payload.code).to.contain('disconnect');
 
-        // No script should have been injected (no matching pattern, no override)
-        expect(env.calls.tabsExecuteScript).to.have.lengthOf(0);
+        // Now fire status:complete to trigger the re-injection for the new URL
+        const completeChangeInfo = { status: 'complete' };
+        tab.status = 'complete';
+        await env.listeners.tabsOnUpdatedListeners[0](tab.id, completeChangeInfo, tab);
+        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // The sequence is:
+        // 1. Initial manual update (Call #1)
+        // 2. Disconnect on URL change (Call #2)
+        // 3. Re-apply guard on status:complete (Call #3)
+        // Any subsequent title-only change would be Call #4 (Fight-back).
+        // If it got 4 already, it means the title change was somehow triggered.
+        expect(env.calls.tabsExecuteScript).to.have.lengthOf.at.least(3);
+        const lastCall = env.calls.tabsExecuteScript[env.calls.tabsExecuteScript.length - 1];
+        expect(lastCall.payload.code).to.contain('MutationObserver');
     });
 
     it('guard is re-installed even when tab title already matches the rule', async function () {

--- a/tests/manual/StateMachineTests.md
+++ b/tests/manual/StateMachineTests.md
@@ -93,3 +93,17 @@
 *   **Step 8.3:** Run "Sync All Tabs".
     *   *Expected:* The Skeptical Engine Phase 1 should log: `Suspicious title prefix detected`. 
     *   *Expected:* Phase 2 wakes the tab, reloads it, and restores the native title because it matches the Title Tamer "Ghost" pattern (`HTTP\d*!`).
+
+---
+
+## 9. Background Hardening & Diagnostics
+**Goal:** Verify diagnostic reliability, guard disconnection during navigation, and Phase 2 guard injection.
+*   **Step 9.1: Diagnostic Toggle:** Enable "Diagnostic Logging" in Options. Open the Background Script Console (Firefox `about:debugging`). 
+    *   *Expected:* Detailed `[DIAG]` logs appear for every navigation and sync. Disable it; logs should stop immediately.
+*   **Step 9.2: Guard Disconnection:** Match a site (e.g., Costco), verify the guard is re-asserting titles. In the same tab, navigate to `google.com`.
+    *   *Expected:* On Google, manually changing the title via console should NOT snap back to the old Costco title. (Proves `onUpdated` URL-change cleanup).
+*   **Step 9.3: Phase 2 Guard Injection:** Have a discarded matching tab. Change its rule in Options.
+    *   *Expected:* Tab wakes up, reloads, and the guard is successfully installed on the active page (verify by attempting to manually change the title).
+*   **Step 9.4: Boot Synchronization:** Enable Diagnostic Logging, restart the extension (Disable/Enable), and immediately open a matching tab.
+    *   *Expected:* Logs show that the background script correctly awaited `loggingReady` before processing the tab event.
+

--- a/tests/manual/StateMachineTests.md
+++ b/tests/manual/StateMachineTests.md
@@ -60,8 +60,8 @@
     *   *Expected:* All 10 tabs instantly swap to the imported definitions without a single page reload (unless discarded with wake-up enabled).
 *   **Step 5.2:** **Hard Refresh:** Navigate to matching URL, check manipulated title, perform Hard Refresh (Ctrl+F5 or Shift+Refresh). 
     *   *Expected:* The `tabs.onUpdated` listener correctly registers the native title pipeline and immediately enforces the manipulated title again. No tracker memory loops or duplicate overwrites.
-*   **Step 5.3:** **Simultaneous Native Override:** Navigate to a site that actively fights you via constant `setInterval` looping `document.title = "Buy Now!"`.
-    *   *Expected:* The extension intercepts the frequent changes, logs them to `tabOriginalTitles`, and re-asserts the manipulated title. (Some extreme visual flickering is normal here, but absolute application stability is expected without Extension-Side crashes).
+*   **Step 5.3:** **Simultaneous Native Override:** Navigate to a site that actively fights you via constant `setInterval` or SPA re-hydration (e.g., `https://www.costco.com/fish-oil-omega-3.html` with a matching rule).
+    *   *Expected:* **Zero flickering.** The extension injects a `MutationObserver` guard directly into the page that synchronously re-asserts the custom title whenever the site's JavaScript attempts to change it. Because this runs inside the page's own JS context, it wins the race with zero round-trip latency. The tab title should lock to the custom value immediately after page load and never visually revert to the site's title. Application stability is also expected (no crashes, no infinite loops).
 
 ---
 

--- a/tests/manual/test_URLs.txt
+++ b/tests/manual/test_URLs.txt
@@ -18,3 +18,5 @@ https://www.ebay.com/itm/123456789
 https://codesandbox.io/s/new
 https://circleci.com/developer/orbs
 https://en.wikipedia.org/wiki/Space_Exploration
+# Fight-back regression test (React/Next.js SPA that re-asserts its own title post-hydration)
+https://www.costco.com/fish-oil-omega-3.html

--- a/tests/manual/test_patterns.json
+++ b/tests/manual/test_patterns.json
@@ -24,6 +24,7 @@
     { "search": "bing\\.com/search\\?q=([^&]+)", "title": "B: $1", "enabled": true, "group": "Search" },
     { "search": "youtube\\.com/watch\\?v=([^&]+)", "title": "YT: $1", "enabled": true, "group": "Media" },
     { "search": "amazon\\.com/dp/([^/]+)", "title": "Amazon: $1", "enabled": true, "group": "Shopping" },
-    { "search": "ebay\\.com/itm/([^/]+)", "title": "eBay: $1", "enabled": true, "group": "Shopping" }
+    { "search": "ebay\\.com/itm/([^/]+)", "title": "eBay: $1", "enabled": true, "group": "Shopping" },
+    { "search": "costco\\.com/([^/]+)\\.html$", "title": "Costco: $1", "enabled": true, "group": "Shopping" }
   ]
 }


### PR DESCRIPTION
Inject an in-page MutationObserver guard to reliably enforce custom tab titles and prevent sites from "fighting back". The background script now always installs the guard when a rule matches (even if the title already equals the rule), clears modified-title records on URL changes, and disconnects the guard when reverting to the original title. Added a memory-cached diagnostic logging flag (diagLogging) with an Options UI checkbox and supporting CSS/layout changes, plus storage sync for immediate toggle effects. Updated/added integration and manual tests and test data to cover guard injection, fight-back detection, URL-change clearing, and revert behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Diagnostic Logging toggle in Developer Tools settings.
  * Options UI: Theme controls and Import/Export now share a compact inline layout.

* **Bug Fixes**
  * Improved title-guard behavior to prevent sites from overwriting custom titles.
  * Better cleanup and restore of native titles when rules are removed or URLs change.
  * More reliable title syncing after wake/boot to maintain consistent title locking.

* **Tests / Documentation**
  * Expanded manual tests and sample URLs to cover SPA “fight-back” scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->